### PR TITLE
Set strategy to 'local' if type is not set

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,10 +66,9 @@ class Service {
   }
 
   create(data, params) {
-    if (data.type) {
-      data.strategy = data.type;
-      delete data.type;
-    }
+    data.strategy = data.type || 'local';
+    delete data.type;
+
     return this.app.service('authentication').create(data, params);
   }
 }


### PR DESCRIPTION
Closed issue #2 does not solve my problem. This fix does.

With feathers-authentication 0.x, the `auth/local` endpoint would
automatically use a local strategy even if one was not set. This
commit sets that strategy.